### PR TITLE
Export label for odoo database

### DIFF
--- a/templates/promtail-config-apps/odoo-role.j2
+++ b/templates/promtail-config-apps/odoo-role.j2
@@ -7,10 +7,11 @@
           # 2020-01-14 13:53:09,585 25306 INFO odoo odoo.addons.base.models.ir_cron: Job `Post process payment transactions` done.
           # 2020-01-14 13:53:22,578 25306 DEBUG ? odoo.service.server: cron0 polling for jobs
           # We exclude milliseconds on purpose because golang's bug https://github.com/golang/go/issues/6189 and odoo's inability to customize logging
-          expression: '^(?P<datetime>[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}),[^ ]+ (?P<process_id>[0-9]+) (?P<loglevel>[a-zA-Z]+) (?P<user>[^ ]+) (?P<module>[^:]+): (?P<message>.*)$'
+          expression: '^(?P<datetime>[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}),[^ ]+ (?P<process_id>[0-9]+) (?P<loglevel>[a-zA-Z]+) (?P<database>[^ ]+) (?P<module>[^:]+): (?P<message>.*)$'
       # Labels to export to Loki and to be indexed there.
       - labels:
           loglevel:
+          database:
       # Source label with datetime data and its golang's layout to parse it
       - timestamp:
           source: datetime


### PR DESCRIPTION
this can be essential for classifying multi-db instances

Right now, odoo is telling us which db a log line corresponds to. However, we are not picking it and therefore can't filter efficiently from grafana. See the image of an example. Note labels are not distinctive from epi or katuma:

![imatge](https://user-images.githubusercontent.com/46573858/74760804-42006a80-527b-11ea-9cd4-108e9cf93a8e.png)

The change at code is simple: we were already parsing the field, but guessed it was the executing user. So let's just rename the label to what it is and mark it for sending at `labels` field.

This upgrade doesn't need any change at inventories, so it can be included in a patch release (our policy says that minor versions are not compatible)