### PR TITLE
Fix postgresql exporter envvars to connect to a DB

### DIFF
--- a/templates/monitoring-docker-compose.yml.j2
+++ b/templates/monitoring-docker-compose.yml.j2
@@ -39,5 +39,7 @@ services:
     network_mode: host
     restart: always
     environment:
-      DATA_SOURCE_NAME: postgresql://{{ monitoring_postgres_exporter_pg_user }}:{{ monitoring_postgres_exporter_pg_password | replace('$','$$')}}@localhost:{{ monitoring_postgres_exporter_pg_port }}/postgres?sslmode=disable
+      DATA_SOURCE_URI: localhost:{{ monitoring_postgres_exporter_pg_port }}/postgres?sslmode=disable
+      DATA_SOURCE_USER: {{ monitoring_postgres_exporter_pg_user }}
+      DATA_SOURCE_PASSWORD: {{ monitoring_postgres_exporter_pg_password | replace('$','$$')}}
 {% endif %}


### PR DESCRIPTION
This fix is to allow passwords with special chars without problem.
In this case, a '#' breaks the DATA_SOURCE_NAME structure